### PR TITLE
Add missing value inspection notebook

### DIFF
--- a/missing_values.ipynb
+++ b/missing_values.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Missing Value Inspection and Handling\n\nThis notebook loads the training and test datasets, inspects all columns for missing values, and applies simple strategies to handle them."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "import pandas as pd\ntrain = pd.read_csv('train.csv')\ntest = pd.read_csv('test.csv')",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Missing value counts"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "print(train.isna().sum())\nprint(test.isna().sum())",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Fill missing numeric columns with median"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "train['Arrival Delay in Minutes'] = train['Arrival Delay in Minutes'].fillna(train['Arrival Delay in Minutes'].median())\ntest['Arrival Delay in Minutes'] = test['Arrival Delay in Minutes'].fillna(test['Arrival Delay in Minutes'].median())",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "train.head()",
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `missing_values.ipynb` to inspect `train.csv`/`test.csv` for nulls
- provide a simple strategy to fill missing `Arrival Delay in Minutes` values with the median

## Testing
- `python passenger_classification.py`