### PR TITLE
Pin stable versions for dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas
-scikit-learn
-numpy
-jupyter
+pandas==1.5.3
+scikit-learn==1.3.2
+numpy==1.24.4
+jupyter==1.0.0


### PR DESCRIPTION
## Summary
- pin pandas, scikit-learn, numpy and jupyter versions in requirements

## Testing
- `python passenger_classification.py`
- attempted to run notebook but `pandas` was missing