### PR TITLE
Add cross-validation and compare models

### DIFF
--- a/passenger_classification.ipynb
+++ b/passenger_classification.ipynb
@@ -1,91 +1,132 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "# Passenger Satisfaction Classification\nThis notebook uses pandas and scikit-learn to train a classifier for airline passenger satisfaction."
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "import pandas as pd\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.preprocessing import OneHotEncoder, StandardScaler\nfrom sklearn.compose import ColumnTransformer\nfrom sklearn.pipeline import Pipeline\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.metrics import accuracy_score, classification_report"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Load the data"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "train_df = pd.read_csv('train.csv').iloc[:, 1:]\ntrain_df = train_df.drop(columns=['id'])\ntrain_df['Arrival Delay in Minutes'] = train_df['Arrival Delay in Minutes'].fillna(0)\ntrain_df.head()"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Descriptive statistics"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "print('Average age:', train_df['Age'].mean())\nprint('Satisfaction counts:')\nprint(train_df['satisfaction'].value_counts())\ntrain_df.describe()"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Train/test split"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "X = train_df.drop('satisfaction', axis=1)\ny = train_df['satisfaction']\n\n# Columns from the original script\nnumeric_features = ['Age', 'Flight Distance', 'Departure Delay in Minutes', 'Arrival Delay in Minutes']\n\ncategorical_features = ['Gender', 'Customer Type', 'Type of Travel', 'Class', 'Inflight wifi service', 'Departure/Arrival time convenient', 'Ease of Online booking', 'Gate location', 'Food and drink', 'Online boarding', 'Seat comfort', 'Inflight entertainment', 'On-board service', 'Leg room service', 'Baggage handling', 'Checkin service', 'Inflight service', 'Cleanliness']\n\nX_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Build the preprocessing and modeling pipeline"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "preprocessor = ColumnTransformer([\n    ('num', StandardScaler(), numeric_features),\n    ('cat', OneHotEncoder(handle_unknown='ignore'), categorical_features)\n])\n\nclf = Pipeline([\n    ('preprocessor', preprocessor),\n    ('model', LogisticRegression(max_iter=1000))\n])"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Train the model"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "clf.fit(X_train, y_train)"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Evaluate"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "y_pred = clf.predict(X_test)\nprint('Accuracy:', accuracy_score(y_test, y_pred))\nprint(classification_report(y_test, y_pred))"
-    }
-  ],
-  "metadata": {},
-  "nbformat": 4,
-  "nbformat_minor": 5
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Passenger Satisfaction Classification\nThis notebook uses pandas and scikit-learn to train a classifier for airline passenger satisfaction."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import pandas as pd\nfrom sklearn.model_selection import train_test_split, cross_validate\nfrom sklearn.preprocessing import OneHotEncoder, StandardScaler\nfrom sklearn.compose import ColumnTransformer\nfrom sklearn.pipeline import Pipeline\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.ensemble import RandomForestClassifier\nfrom sklearn.svm import SVC\nfrom sklearn.metrics import accuracy_score, classification_report"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Load the data"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "train_df = pd.read_csv('train.csv').iloc[:, 1:]\ntrain_df = train_df.drop(columns=['id'])\ntrain_df['Arrival Delay in Minutes'] = train_df['Arrival Delay in Minutes'].fillna(0)\ntrain_df.head()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Descriptive statistics"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "print('Average age:', train_df['Age'].mean())\nprint('Satisfaction counts:')\nprint(train_df['satisfaction'].value_counts())\ntrain_df.describe()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Train/test split"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "X = train_df.drop('satisfaction', axis=1)\ny = train_df['satisfaction']\n\n# Columns from the original script\nnumeric_features = ['Age', 'Flight Distance', 'Departure Delay in Minutes', 'Arrival Delay in Minutes']\n\ncategorical_features = ['Gender', 'Customer Type', 'Type of Travel', 'Class', 'Inflight wifi service', 'Departure/Arrival time convenient', 'Ease of Online booking', 'Gate location', 'Food and drink', 'Online boarding', 'Seat comfort', 'Inflight entertainment', 'On-board service', 'Leg room service', 'Baggage handling', 'Checkin service', 'Inflight service', 'Cleanliness']\n\nX_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Build the preprocessing and modeling pipeline"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "preprocessor = ColumnTransformer([\n    ('num', StandardScaler(), numeric_features),\n    ('cat', OneHotEncoder(handle_unknown='ignore'), categorical_features)\n])\n\nclf = Pipeline([\n    ('preprocessor', preprocessor),\n    ('model', LogisticRegression(max_iter=1000))\n])"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Cross-validation"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "cv_results = cross_validate(\n    clf, X, y, cv=5,\n    scoring=['accuracy', 'precision_macro', 'recall_macro']\n)\nprint('CV accuracy:', cv_results['test_accuracy'].mean())\nprint('CV precision:', cv_results['test_precision_macro'].mean())\nprint('CV recall:', cv_results['test_recall_macro'].mean())"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Train the model"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "clf.fit(X_train, y_train)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Evaluate"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "y_pred = clf.predict(X_test)\nprint('Accuracy:', accuracy_score(y_test, y_pred))\nprint(classification_report(y_test, y_pred))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Random Forest"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "rf_clf = Pipeline([\n    ('preprocessor', preprocessor),\n    ('model', RandomForestClassifier(n_estimators=100, random_state=42))\n])\nrf_clf.fit(X_train, y_train)\ny_pred_rf = rf_clf.predict(X_test)\nprint('Accuracy:', accuracy_score(y_test, y_pred_rf))\nprint(classification_report(y_test, y_pred_rf))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Support Vector Machine"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "svm_clf = Pipeline([\n    ('preprocessor', preprocessor),\n    ('model', SVC())\n])\nsvm_clf.fit(X_train, y_train)\ny_pred_svm = svm_clf.predict(X_test)\nprint('Accuracy:', accuracy_score(y_test, y_pred_svm))\nprint(classification_report(y_test, y_pred_svm))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Summary\nThe printed metrics above show the average cross-validated accuracy, precision and recall for logistic regression. Metrics for Random Forest and SVM are also displayed."
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- extend imports to include cross-validation and more models
- run 5-fold cross validation for logistic regression
- add optional Random Forest and SVM evaluations
- summarize results in notebook comments

## Testing
- `python passenger_classification.py`